### PR TITLE
Include Content-Format option in the response

### DIFF
--- a/coap.c
+++ b/coap.c
@@ -368,7 +368,7 @@ int coap_make_response(coap_rw_buffer_t *scratch, coap_packet_t *pkt, const uint
     pkt->hdr.code = rspcode;
     pkt->hdr.id[0] = msgid_hi;
     pkt->hdr.id[1] = msgid_lo;
-    pkt->numopts = 0;
+    pkt->numopts = 1;
 
     // need token in response
     if (tok) {


### PR DESCRIPTION
The response does not include `Content-Format` option. It causes Copper to fail requesting `.well-known` as the content format of the response is not `application/link-format`.