### PR TITLE
Stop clearing request's memory

### DIFF
--- a/microcoap.ino
+++ b/microcoap.ino
@@ -83,7 +83,6 @@ void loop()
             coap_packet_t rsppkt;
             coap_handle_req(&scratch_buf, &pkt, &rsppkt);
 
-            memset(packetbuf, 0, UDP_TX_PACKET_MAX_SIZE);
             if (0 != (rc = coap_build(packetbuf, &rsplen, &rsppkt)))
             {
                 Serial.print("coap_build failed rc=");


### PR DESCRIPTION
Clearing packetbuf wipes out data for the request packet. After memset the request token is lost and it cannot be copied to the response.