### PR TITLE
Fix types of coap_option_nibble()

### DIFF
--- a/coap.c
+++ b/coap.c
@@ -294,13 +294,14 @@ int coap_build(uint8_t *buf, size_t *buflen, const coap_packet_t *pkt)
 
     for (i=0;i<pkt->numopts;i++)
     {
-        uint8_t optDelta, len, delta = 0;
+        uint32_t optDelta;
+        uint8_t len, delta = 0;
 
         if (p-buf > *buflen)
              return COAP_ERR_BUFFER_TOO_SMALL;
         optDelta = pkt->opts[i].num - running_delta;
         coap_option_nibble(optDelta, &delta);
-        coap_option_nibble(pkt->opts[i].buf.len, &len);
+        coap_option_nibble((uint32_t)pkt->opts[i].buf.len, &len);
 
         *p++ = (0xFF & (delta << 4 | len));
         if (delta == 13)
@@ -344,7 +345,7 @@ int coap_build(uint8_t *buf, size_t *buflen, const coap_packet_t *pkt)
     return 0;
 }
 
-void coap_option_nibble(uint8_t value, uint8_t *nibble)
+void coap_option_nibble(uint32_t value, uint8_t *nibble)
 {
     if (value<13)
     {

--- a/coap.h
+++ b/coap.h
@@ -153,7 +153,7 @@ int coap_build(uint8_t *buf, size_t *buflen, const coap_packet_t *pkt);
 void coap_dump(const uint8_t *buf, size_t buflen, bool bare);
 int coap_make_response(coap_rw_buffer_t *scratch, coap_packet_t *pkt, const uint8_t *content, size_t content_len, uint8_t msgid_hi, uint8_t msgid_lo, const coap_buffer_t* tok, coap_responsecode_t rspcode, coap_content_type_t content_type);
 int coap_handle_req(coap_rw_buffer_t *scratch, const coap_packet_t *inpkt, coap_packet_t *outpkt);
-void coap_option_nibble(uint8_t value, uint8_t *nibble);
+void coap_option_nibble(uint32_t value, uint8_t *nibble);
 void coap_setup(void);
 void endpoint_setup(void);
 


### PR DESCRIPTION
Input values for coap_option_nibble() can be > 0xffff; i. e. type must
be uint32_t.