### PR TITLE
Update links from draft-18 to rfc7252

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ microcoap
 =========
 
 A tiny CoAP server for microcontrollers.
-See http://tools.ietf.org/html/draft-ietf-core-coap-18
+See http://tools.ietf.org/html/rfc7252
 
 Endpoint handlers are defined in endpoints.c
 

--- a/coap.c
+++ b/coap.c
@@ -150,7 +150,7 @@ int coap_parseOption(coap_option_t *option, uint16_t *running_delta, const uint8
     return 0;
 }
 
-// http://tools.ietf.org/html/draft-ietf-core-coap-18#section-3.1
+// http://tools.ietf.org/html/rfc7252#section-3.1
 int coap_parseOptionsAndPayload(coap_option_t *options, uint8_t *numOptions, coap_buffer_t *payload, const coap_header_t *hdr, const uint8_t *buf, size_t buflen)
 {
     size_t optionIndex = 0;
@@ -288,7 +288,7 @@ int coap_build(uint8_t *buf, size_t *buflen, const coap_packet_t *pkt)
     if (pkt->hdr.tkl > 0)
         memcpy(p, pkt->tok.p, pkt->hdr.tkl);
 
-    // http://tools.ietf.org/html/draft-ietf-core-coap-18#section-3.1
+    // // http://tools.ietf.org/html/rfc7252#section-3.1
     // inject options
     p += pkt->hdr.tkl;
 

--- a/coap.h
+++ b/coap.h
@@ -11,7 +11,7 @@ extern "C" {
 
 #define MAXOPT 16
 
-// http://tools.ietf.org/html/draft-ietf-core-coap-18#section-3
+//http://tools.ietf.org/html/rfc7252#section-3
 typedef struct
 {
     uint8_t ver;
@@ -50,7 +50,7 @@ typedef struct
 
 /////////////////////////////////////////
 
-//http://tools.ietf.org/html/draft-ietf-core-coap-18#section-12.2
+//http://tools.ietf.org/html/rfc7252#section-12.2
 typedef enum
 {
     COAP_OPTION_IF_MATCH = 1,
@@ -70,7 +70,7 @@ typedef enum
     COAP_OPTION_PROXY_SCHEME = 39
 } coap_option_num_t;
 
-//http://tools.ietf.org/html/draft-ietf-core-coap-18#section-12.1.1
+//http://tools.ietf.org/html/rfc7252#section-12.1.1
 typedef enum
 {
     COAP_METHOD_GET = 1,
@@ -79,7 +79,7 @@ typedef enum
     COAP_METHOD_DELETE = 4
 } coap_method_t;
 
-//http://tools.ietf.org/html/draft-ietf-core-coap-18#section-12.1.1
+//http://tools.ietf.org/html/rfc7252#section-12.1.1
 typedef enum
 {
     COAP_TYPE_CON = 0,
@@ -88,8 +88,8 @@ typedef enum
     COAP_TYPE_RESET = 3
 } coap_msgtype_t;
 
-//http://tools.ietf.org/html/draft-ietf-core-coap-18#section-5.2
-//http://tools.ietf.org/html/draft-ietf-core-coap-18#section-12.1.2
+//http://tools.ietf.org/html/rfc7252#section-5.2
+//http://tools.ietf.org/html/rfc7252#section-12.1.2
 #define MAKE_RSPCODE(clas, det) ((clas << 5) | (det))
 typedef enum
 {
@@ -99,7 +99,7 @@ typedef enum
     COAP_RSPCODE_CHANGED = MAKE_RSPCODE(2, 4)
 } coap_responsecode_t;
 
-//http://tools.ietf.org/html/draft-ietf-core-coap-18#section-12.3
+//http://tools.ietf.org/html/rfc7252#section-12.3
 typedef enum
 {
     COAP_CONTENTTYPE_NONE = -1, // bodge to allow us not to send option block


### PR DESCRIPTION
Hi,
I've noticed that the references point to an old draft of the CoAP RFC, so I updated them to point to the actual RFC. They're double-checked to prevent any confusion which may have been caused by any reordering between draft-ietf-core-coap-18 and rfc7252.