### PR TITLE
document more complex structs

### DIFF
--- a/coap.h
+++ b/coap.h
@@ -14,17 +14,19 @@ extern "C" {
 //http://tools.ietf.org/html/rfc7252#section-3
 typedef struct
 {
-    uint8_t ver;
-    uint8_t t;
-    uint8_t tkl;
-    uint8_t code;
+    uint8_t ver;                /* CoAP version number */
+    uint8_t t;                  /* CoAP Message Type */
+    uint8_t tkl;                /* Token length: indicates length of the Token field */
+    uint8_t code;               /* CoAP status code. Can be request (0.xx), success reponse (2.xx), 
+                                 * client error response (4.xx), or rever error response (5.xx) 
+                                 * For possible values, see http://tools.ietf.org/html/rfc7252#section-12.1 */
     uint8_t id[2];
 } coap_header_t;
 
 typedef struct
 {
-    const uint8_t *p;
-    size_t len;
+    uint8_t num;                /* Option number. See http://tools.ietf.org/html/rfc7252#section-5.10 */
+    coap_buffer_t buf;          /* Option value */
 } coap_buffer_t;
 
 typedef struct
@@ -41,11 +43,12 @@ typedef struct
 
 typedef struct
 {
-    coap_header_t hdr;
-    coap_buffer_t tok;
-    uint8_t numopts;
-    coap_option_t opts[MAXOPT];
-    coap_buffer_t payload;
+    coap_header_t hdr;          /* Header of the packet */
+    coap_buffer_t tok;          /* Token value, size as specified by hdr.tkl */
+    uint8_t numopts;            /* Number of options */
+    coap_option_t opts[MAXOPT]; /* Options of the packet. For possible entries see
+                                 * http://tools.ietf.org/html/rfc7252#section-5.10 */
+    coap_buffer_t payload;      /* Payload carried by the packet */
 } coap_packet_t;
 
 /////////////////////////////////////////
@@ -137,10 +140,16 @@ typedef struct
 
 typedef struct
 {
-    coap_method_t method;
-    coap_endpoint_func handler;
-    const coap_endpoint_path_t *path;
-    const char *core_attr;
+    coap_method_t method;               /* (i.e. POST, PUT or GET) */
+    coap_endpoint_func handler;         /* callback function which handles this 
+                                         * type of endpoint (and calls 
+                                         * coap_make_response() at some point) */
+    const coap_endpoint_path_t *path;   /* path towards a resource (i.e. foo/bar/) */ 
+    const char *core_attr;              /* the 'ct' attribute, as defined in RFC7252, section 7.2.1.:
+                                         * "The Content-Format code "ct" attribute 
+                                         * provides a hint about the 
+                                         * Content-Formats this resource returns." 
+                                         * (Section 12.3. lists possible ct values.) */
 } coap_endpoint_t;
 
 


### PR DESCRIPTION
Document the more complex structs. Same as https://github.com/1248/microcoap/pull/13, but without any type changes.