### PR TITLE
compile-time MICROCOAP_MAX_SEGMENTS

### DIFF
--- a/coap.h
+++ b/coap.h
@@ -135,11 +135,13 @@ typedef enum
 ///////////////////////
 
 typedef int (*coap_endpoint_func)(coap_rw_buffer_t *scratch, const coap_packet_t *inpkt, coap_packet_t *outpkt, uint8_t id_hi, uint8_t id_lo);
-#define MAX_SEGMENTS 2  // 2 = /foo/bar, 3 = /foo/bar/baz
+#ifndef MICROCOAP_MAX_SEGMENTS
+#define MICROCOAP_MAX_SEGMENTS 2  // 2 = /foo/bar, 3 = /foo/bar/baz
+#endif // MICROCOAP_MAX_SEGMENTS
 typedef struct
 {
     int count;
-    const char *elems[MAX_SEGMENTS];
+    const char *elems[MICROCOAP_MAX_SEGMENTS];
 } coap_endpoint_path_t;
 
 typedef struct


### PR DESCRIPTION
allow to specify max number of uri-path segments during build without modifying the source