### PR TITLE
omit content-format option when COAP_CONTENTTYPE_NONE is given

### DIFF
--- a/coap.c
+++ b/coap.c
@@ -369,7 +369,7 @@ int coap_make_response(coap_rw_buffer_t *scratch, coap_packet_t *pkt, const uint
     pkt->hdr.code = rspcode;
     pkt->hdr.id[0] = msgid_hi;
     pkt->hdr.id[1] = msgid_lo;
-    pkt->numopts = 1;
+    pkt->numopts = 0;
 
     // need token in response
     if (tok) {
@@ -377,14 +377,17 @@ int coap_make_response(coap_rw_buffer_t *scratch, coap_packet_t *pkt, const uint
         pkt->tok = *tok;
     }
 
-    // safe because 1 < MAXOPT
-    pkt->opts[0].num = COAP_OPTION_CONTENT_FORMAT;
-    pkt->opts[0].buf.p = scratch->p;
-    if (scratch->len < 2)
-        return COAP_ERR_BUFFER_TOO_SMALL;
-    scratch->p[0] = ((uint16_t)content_type & 0xFF00) >> 8;
-    scratch->p[1] = ((uint16_t)content_type & 0x00FF);
-    pkt->opts[0].buf.len = 2;
+    if (content_type != COAP_CONTENTTYPE_NONE) {
+        pkt->numopts = 1;
+        // safe because 1 < MAXOPT
+        pkt->opts[0].num = COAP_OPTION_CONTENT_FORMAT;
+        pkt->opts[0].buf.p = scratch->p;
+        if (scratch->len < 2)
+            return COAP_ERR_BUFFER_TOO_SMALL;
+        scratch->p[0] = ((uint16_t)content_type & 0xFF00) >> 8;
+        scratch->p[1] = ((uint16_t)content_type & 0x00FF);
+        pkt->opts[0].buf.len = 2;
+    }
     pkt->payload.p = content;
     pkt->payload.len = content_len;
     return 0;


### PR DESCRIPTION
when calling `coap_make_response` with content_type == COAP_CONTENTTYPE_NONE (i.e. for an ACK response message), response will contain this option with a value of 65535 (-1, as defined in coap.h), but client may report this as an unknown content format.

added check, if COAP_CONTENTTYPE_NONE is given, omit the option. include otherwise.